### PR TITLE
Hide seconds on DateTime widget

### DIFF
--- a/Win10 Widgets/DateTime/DateTime-Large.ini
+++ b/Win10 Widgets/DateTime/DateTime-Large.ini
@@ -205,10 +205,11 @@ DynamicVariables=1
 ; Shows second colon in time (between minutes and seconds).
 Meter=String
 MeterStyle=StyleBigText | StyleCenterAlign
-X=([TimeMinute2:X]+[TimeMinute2:W]-16)
+X=([TimeMinute2:X]+[TimeMinute2:W])
 Y=([TimeMinute2:Y]-4)
 W=#ColonWidth#
 Text=":"
+DynamicVariables=1
 Hidden=0
 
 [TimeSecond1]
@@ -220,6 +221,7 @@ X=1R
 Y=4r
 W=#NumberWidth#
 Text="%1"
+DynamicVariables=1
 Hidden=0
 
 [TimeSecond2]
@@ -231,6 +233,7 @@ X=-8R
 Y=0r
 W=#NumberWidth#
 Text="%1"
+DynamicVariables=1
 Hidden=0
 
 [TimeAMPM]

--- a/Win10 Widgets/DateTime/DateTime-Large.ini
+++ b/Win10 Widgets/DateTime/DateTime-Large.ini
@@ -205,7 +205,7 @@ DynamicVariables=1
 ; Shows second colon in time (between minutes and seconds).
 Meter=String
 MeterStyle=StyleBigText | StyleCenterAlign
-X=([TimeMinute2:X]+[TimeMinute2:W]+16-16)
+X=([TimeMinute2:X]+[TimeMinute2:W]-16)
 Y=([TimeMinute2:Y]-4)
 W=#ColonWidth#
 Text=":"

--- a/Win10 Widgets/DateTime/DateTime-Large.ini
+++ b/Win10 Widgets/DateTime/DateTime-Large.ini
@@ -25,6 +25,12 @@ ContextAction=[!WriteKeyValue MeasureHour Format %#I #CoreFilePath#][!WriteKeyVa
 ; Context menu option to change time to 24-hour format (hides AM/PM)
 ContextTitle2="24-hour time"
 ContextAction2=[!WriteKeyValue MeasureHour Format %#H #CoreFilePath#][!WriteKeyValue MeasureAMPM Disabled 1 #CoreFilePath#][!WriteKeyValue TimeAMPM Hidden 1 #CoreFilePath#][!Refresh]
+; Context menu option to hide seconds
+ContextTitle3="Hide seconds"
+ContextAction3=[!WriteKeyValue TimeColon2 Hidden 1 #CoreFilePath#][!WriteKeyValue TimeSecond1 Hidden 1 #CoreFilePath#][!WriteKeyValue TimeSecond2 Hidden 1 #CoreFilePath#][!Refresh]
+; Context menu option to show seconds
+ContextTitle4="Show seconds"
+ContextAction4=[!WriteKeyValue TimeColon2 Hidden 0 #CoreFilePath#][!WriteKeyValue TimeSecond1 Hidden 0 #CoreFilePath#][!WriteKeyValue TimeSecond2 Hidden 0 #CoreFilePath#][!Refresh]
 
 [Metadata]
 Name=Date/Time (large)
@@ -183,35 +189,6 @@ Y=0r
 W=#NumberWidth#
 Text="%1"
 
-[TimeColon2]
-; Shows second colon in time (between minutes and seconds).
-Meter=String
-MeterStyle=StyleBigText | StyleCenterAlign
-X=-16R
-Y=-4r
-W=#ColonWidth#
-Text=":"
-
-[TimeSecond1]
-; Shows first digit of seconds.
-Meter=String
-MeterStyle=StyleBigText | StyleCenterAlign
-MeasureName=MeasureSecond1
-X=1R
-Y=4r
-W=#NumberWidth#
-Text="%1"
-
-[TimeSecond2]
-; Shows second digit of seconds.
-Meter=String
-MeterStyle=StyleBigText | StyleCenterAlign
-MeasureName=MeasureSecond2
-X=-8R
-Y=0r
-W=#NumberWidth#
-Text="%1"
-
 [Date]
 ; Shows date (day, month date, year).
 Meter=String
@@ -224,13 +201,45 @@ ClipString=2
 ClipStringW=(#BackgroundWidth#-#LeftPadding#-5)
 DynamicVariables=1
 
+[TimeColon2]
+; Shows second colon in time (between minutes and seconds).
+Meter=String
+MeterStyle=StyleBigText | StyleCenterAlign
+X=([TimeMinute2:X]+[TimeMinute2:W]+16-16)
+Y=([TimeMinute2:Y]-4)
+W=#ColonWidth#
+Text=":"
+Hidden=0
+
+[TimeSecond1]
+; Shows first digit of seconds.
+Meter=String
+MeterStyle=StyleBigText | StyleCenterAlign
+MeasureName=MeasureSecond1
+X=1R
+Y=4r
+W=#NumberWidth#
+Text="%1"
+Hidden=0
+
+[TimeSecond2]
+; Shows second digit of seconds.
+Meter=String
+MeterStyle=StyleBigText | StyleCenterAlign
+MeasureName=MeasureSecond2
+X=-8R
+Y=0r
+W=#NumberWidth#
+Text="%1"
+Hidden=0
+
 [TimeAMPM]
 ; Shows AM or PM for 12 hour time format.
 Meter=String
 MeterStyle=StyleMediumText | StyleCenterAlign
 MeasureName=MeasureAMPM
-X=([TimeSecond2:X]+[TimeSecond2:W]+22)
-Y=([TimeSecond2:Y]+29)
+X=([TimeMinute2:X]+[TimeMinute2:W]+([TimeSecond2:W]>0?([TimeSecond2:X]+[TimeSecond2:W])-([TimeMinute2:X]+[TimeMinute2:W]):0)+22)
+Y=([TimeMinute2:Y]+29)
 W=90
 Text="%1"
 FontSize=15

--- a/Win10 Widgets/DateTime/DateTime-Medium.ini
+++ b/Win10 Widgets/DateTime/DateTime-Medium.ini
@@ -55,10 +55,13 @@ Y=2r
 [TimeMinute2]
 MeterStyle=StyleMediumText | StyleCenterAlign
 
+[Date]
+Y=0R
+
 [TimeColon2]
 MeterStyle=StyleMediumText | StyleCenterAlign
-X=-11R
-Y=-2r
+X=([TimeMinute2:X]+[TimeMinute2:W]+11-11)
+Y=([TimeMinute2:Y]-2)
 
 [TimeSecond1]
 MeterStyle=StyleMediumText | StyleCenterAlign
@@ -68,11 +71,8 @@ Y=2r
 [TimeSecond2]
 MeterStyle=StyleMediumText | StyleCenterAlign
 
-[Date]
-Y=0R
-
 [TimeAMPM]
 MeterStyle=StyleSmallText | StyleCenterAlign
-X=([TimeSecond2:X]+[TimeSecond2:W]+15)
-Y=([TimeSecond2:Y]+10)
+X=([TimeMinute2:X]+[TimeMinute2:W]+([TimeSecond2:W]>0?([TimeSecond2:X]+[TimeSecond2:W])-([TimeMinute2:X]+[TimeMinute2:W]):0)+15)
+Y=([TimeMinute2:Y]+10)
 FontSize=11

--- a/Win10 Widgets/DateTime/DateTime-Medium.ini
+++ b/Win10 Widgets/DateTime/DateTime-Medium.ini
@@ -60,7 +60,7 @@ Y=0R
 
 [TimeColon2]
 MeterStyle=StyleMediumText | StyleCenterAlign
-X=([TimeMinute2:X]+[TimeMinute2:W]+11-11)
+X=([TimeMinute2:X]+[TimeMinute2:W]-11)
 Y=([TimeMinute2:Y]-2)
 
 [TimeSecond1]

--- a/Win10 Widgets/DateTime/DateTime-Medium.ini
+++ b/Win10 Widgets/DateTime/DateTime-Medium.ini
@@ -60,7 +60,7 @@ Y=0R
 
 [TimeColon2]
 MeterStyle=StyleMediumText | StyleCenterAlign
-X=([TimeMinute2:X]+[TimeMinute2:W]-11)
+X=([TimeMinute2:X]+[TimeMinute2:W])
 Y=([TimeMinute2:Y]-2)
 
 [TimeSecond1]

--- a/Win10 Widgets/DateTime/DateTime-Small.ini
+++ b/Win10 Widgets/DateTime/DateTime-Small.ini
@@ -63,10 +63,13 @@ Y=1r
 X=-4R
 FontSize=11
 
+[Date]
+Y=0R
+
 [TimeColon2]
-X=-6R
+X=([TimeMinute2:X]+[TimeMinute2:W]+11-6)
 FontSize=11
-Y=-1r
+Y=([TimeMinute2:Y]-1)
 
 [TimeSecond1]
 FontSize=11
@@ -76,11 +79,8 @@ Y=1r
 X=-4R
 FontSize=11
 
-[Date]
-Y=0R
-
 [TimeAMPM]
-X=([TimeSecond2:X]+[TimeSecond2:W]+12)
-Y=([TimeSecond2:Y]+3)
+X=([TimeMinute2:X]+[TimeMinute2:W]+([TimeSecond2:W]>0?([TimeSecond2:X]+[TimeSecond2:W])-([TimeMinute2:X]+[TimeMinute2:W]):0)+12)
+Y=([TimeMinute2:Y]+3)
 W=27
 FontSize=9

--- a/Win10 Widgets/DateTime/DateTime-Small.ini
+++ b/Win10 Widgets/DateTime/DateTime-Small.ini
@@ -67,7 +67,7 @@ FontSize=11
 Y=0R
 
 [TimeColon2]
-X=([TimeMinute2:X]+[TimeMinute2:W]+6-6)
+X=([TimeMinute2:X]+[TimeMinute2:W])
 FontSize=11
 Y=([TimeMinute2:Y]-1)
 

--- a/Win10 Widgets/DateTime/DateTime-Small.ini
+++ b/Win10 Widgets/DateTime/DateTime-Small.ini
@@ -67,7 +67,7 @@ FontSize=11
 Y=0R
 
 [TimeColon2]
-X=([TimeMinute2:X]+[TimeMinute2:W]+11-6)
+X=([TimeMinute2:X]+[TimeMinute2:W]+6-6)
 FontSize=11
 Y=([TimeMinute2:Y]-1)
 

--- a/Win10 Widgets/DateTime/DateTime-Tiny.ini
+++ b/Win10 Widgets/DateTime/DateTime-Tiny.ini
@@ -34,6 +34,6 @@ BackgroundHeight=47
 
 [Date]
 X=([TimeAMPM:X]+[TimeAMPM:W]+15)
-Y=[TimeSecond2:Y]
+Y=[TimeMinute2:Y]
 ClipStringW=(#BackgroundWidth#-[TimeAMPM:X]-[TimeAMPM:W]-20)
 ClipStringH=20


### PR DESCRIPTION
Hi! I find clocks that display seconds annoying so I added the option to hide them. I am fairly new to Rainmeter, but I tested the changes on my local machine and it seems to work pretty well.